### PR TITLE
Add channel as the return path from Parse() to the caller.

### DIFF
--- a/rpsl-parser/README.md
+++ b/rpsl-parser/README.md
@@ -1,4 +1,6 @@
 ![coverage](./coverage_badge.png "Coverage")
+![buildstatus](https://api.travis-ci.org/morrowc/contrib.svg?branch=master "BuildStatus")
+![goreportcard](https://goreportcard.com/badge/github.com/manrs-tools/contrib "Go Report Card")
 
 A library to parse IRR database data.
 

--- a/rpsl-parser/coverage.html
+++ b/rpsl-parser/coverage.html
@@ -54,7 +54,7 @@
 			<div id="nav">
 				<select id="files">
 
-				<option value="file0">./irr.go (90.9%)</option>
+				<option value="file0">./irr.go (89.4%)</option>
 
 				<option value="file1">./util.go (85.0%)</option>
 
@@ -94,6 +94,8 @@ import (
         "fmt"
         "io"
         "strings"
+
+        glog "github.com/golang/glog"
 )
 
 // Reader is a struct to manage access to the irr database file.
@@ -409,36 +411,42 @@ func (r *Reader) initRecord() (*Record, error) <span class="cov8" title="1">{
 }
 
 // Parse parses through the content sending resulting records into a channel to the caller.
-func Parse(rdr *Reader, rc chan&lt;- *Record) error <span class="cov8" title="1">{
+func Parse(rdr *Reader, rc chan&lt;- *Record) <span class="cov8" title="1">{
         // Read the file content, return all accumulated records.
         // Return in case of parsing errors on record/keyword type.
         // Return in case of reading error.
         for </span><span class="cov8" title="1">{
                 rec, err := rdr.initRecord()
                 if err != nil </span><span class="cov8" title="1">{
-                        return fmt.Errorf("failed to init the first Record: %v", err)
+                        glog.Infof("failed to init the first Record: %v", err)
+                        return
                 }</span>
 
                 <span class="cov8" title="1">for </span><span class="cov8" title="1">{
                         key, literal := rdr.findKey()
                         if key == ILLEGAL </span><span class="cov0" title="0">{
-                                return fmt.Errorf("failed to read a keyword found unexpected: %v\n", literal)
-                        }</span>
+                                glog.Infof("failed to read a keyword found unexpected: %v\n", literal)
+                                break</span>
+                        }
 
                         <span class="cov8" title="1">err := rdr.consumeColon()
                         if err != nil </span><span class="cov0" title="0">{
                                 rc &lt;- rec
-                                return fmt.Errorf("failed to consume a key's colon separator: %v", err)
-                        }</span>
+                                glog.Infof("failed to consume a key's colon separator: %v", err)
+                                break</span>
+                        }
 
                         <span class="cov8" title="1">val, re, err := rdr.readValue()
                         if err != nil </span><span class="cov8" title="1">{
                                 rec.Fields[key] = val
                                 rc &lt;- rec
                                 if err == io.EOF </span><span class="cov8" title="1">{
-                                        return fmt.Errorf("found an EOF while reading a value: %v", err)
+                                        // EOF in a read means moving to the next file.
+                                        glog.Infof("found an EOF while reading a value: %v", err)
+                                        return
                                 }</span>
-                                <span class="cov0" title="0">return fmt.Errorf("failed to read a value: %v", err)</span>
+                                <span class="cov0" title="0">glog.Infof("failed to read a value: %v", err)
+                                return</span>
                         }
 
                         // Add the key/value to the record as well.

--- a/rpsl-parser/coverage.html
+++ b/rpsl-parser/coverage.html
@@ -54,7 +54,7 @@
 			<div id="nav">
 				<select id="files">
 
-				<option value="file0">./irr.go (91.0%)</option>
+				<option value="file0">./irr.go (90.4%)</option>
 
 				<option value="file1">./util.go (85.0%)</option>
 
@@ -409,52 +409,52 @@ func (r *Reader) initRecord() (*Record, error) <span class="cov8" title="1">{
 }
 
 // Parse parses through the content sending resulting records into a channel to the caller.
-func Parse(rdr *Reader, rc chan&lt;- *Record) error {
+func Parse(rdr *Reader, rc chan&lt;- *Record) error <span class="cov8" title="1">{
         // Read the file content, return all accumulated records.
         // Return in case of parsing errors on record/keyword type.
         // Return in case of reading error.
-        for {
+        for </span><span class="cov8" title="1">{
                 rec, err := rdr.initRecord()
-                if err != nil {
+                if err != nil </span><span class="cov8" title="1">{
                         return fmt.Errorf("failed to init the first Record: %v", err)
-                }
+                }</span>
 
-                for</span><span class="cov8" title="1"> {
+                <span class="cov8" title="1">for </span><span class="cov8" title="1">{
                         key, literal := rdr.findKey()
-                        if key == ILL</span><span class="cov8" title="1">EGAL {
+                        if key == ILLEGAL </span><span class="cov0" title="0">{
                                 return fmt.Errorf("failed to read a keyword found unexpected: %v\n", literal)
-                        </span>}
+                        }</span>
 
-                <span class="cov8" title="1">        err</span><span class="cov8" title="1"> := rdr.consumeColon()
-                        if err != nil {
+                        <span class="cov8" title="1">err := rdr.consumeColon()
+                        if err != nil </span><span class="cov0" title="0">{
                                 rc &lt;- rec
-</span>                                return fmt.Errorf("failed to consume a key's colon separator: %v", err)
+                                return fmt.Errorf("failed to consume a key's colon separator: %v", err)
                         }</span>
 
                         <span class="cov8" title="1">val, re, err := rdr.readValue()
-                        if err != nil </span><span class="cov0" title="0">{
+                        if err != nil </span><span class="cov8" title="1">{
                                 rec.Fields[key] = val
                                 rc &lt;- rec
-                                </span>if err == io.EOF {
+                                if err == io.EOF </span><span class="cov8" title="1">{
                                         return fmt.Errorf("found an EOF while reading a value: %v", err)
-                        <span class="cov8" title="1">        }
-                                return fmt.Er</span><span class="cov8" title="1">rorf("failed to read a value: %v", err)
+                                }</span>
+                                <span class="cov0" title="0">return fmt.Errorf("failed to read a value: %v", err)</span>
                         }
 
-                        // Add the key/val</span><span class="cov8" title="1">ue to the record as well.
-                        if _, ok := rec.Fields[key]; !ok {
-                                r</span>ec.Fields[key] = val
-                        }<span class="cov0" title="0"> else {
-</span>                                rec.Fields[key] = fmt.Sprintf("%v %v", rec.Fields[key], val)
-                        }
+                        // Add the key/value to the record as well.
+                        <span class="cov8" title="1">if _, ok := rec.Fields[key]; !ok </span><span class="cov8" title="1">{
+                                rec.Fields[key] = val
+                        }</span><span class="cov8" title="1"> else {
+                                rec.Fields[key] = fmt.Sprintf("%v %v", rec.Fields[key], val)
+                        }</span>
 
-                        <span class="cov8" title="1">if re {
-</span>                                break
-                        }</span><span class="cov8" title="1">
+                        <span class="cov8" title="1">if re </span><span class="cov8" title="1">{
+                                break</span>
+                        }
                 }
-                rc</span> &lt;- rec
+                <span class="cov8" title="1">rc &lt;- rec</span>
         }
-        re<span class="cov8" title="1">turn n</span><span class="cov8" title="1">il
+        <span class="cov0" title="0">return nil</span>
 }
 </pre>
 

--- a/rpsl-parser/coverage.html
+++ b/rpsl-parser/coverage.html
@@ -408,60 +408,53 @@ func (r *Reader) initRecord() (*Record, error) <span class="cov8" title="1">{
         <span class="cov8" title="1">return rec, nil</span>
 }
 
-// Parse parses through the content creating records.
-// TODO(morrowc): Convert this from sending back a single
-// set of Records to pipelining parsed *Record records
-// over a channel for coalation by the larger operating process.
-func Parse(rdr *Reader) (Records, error) <span class="cov8" title="1">{
-        // Create the record to fill.
-        var rs Records
-
+// Parse parses through the content sending resulting records into a channel to the caller.
+func Parse(rdr *Reader, rc chan&lt;- *Record) error {
         // Read the file content, return all accumulated records.
         // Return in case of parsing errors on record/keyword type.
         // Return in case of reading error.
-        for </span><span class="cov8" title="1">{
+        for {
                 rec, err := rdr.initRecord()
-                if err != nil </span><span class="cov8" title="1">{
-                        return rs, err
-                }</span>
+                if err != nil {
+                        return fmt.Errorf("failed to init the first Record: %v", err)
+                }
 
-                <span class="cov8" title="1">for </span><span class="cov8" title="1">{
+                for</span><span class="cov8" title="1"> {
                         key, literal := rdr.findKey()
-                        if key == ILLEGAL </span><span class="cov0" title="0">{
-                                return rs, fmt.Errorf("failed to read a keyword found unexpected: %v\n", literal)
-                        }</span>
+                        if key == ILL</span><span class="cov8" title="1">EGAL {
+                                return fmt.Errorf("failed to read a keyword found unexpected: %v\n", literal)
+                        </span>}
 
-                        <span class="cov8" title="1">err := rdr.consumeColon()
-                        if err != nil </span><span class="cov0" title="0">{
-                                rs = append(rs, rec)
-                                return rs, err
+                <span class="cov8" title="1">        err</span><span class="cov8" title="1"> := rdr.consumeColon()
+                        if err != nil {
+                                rc &lt;- rec
+</span>                                return fmt.Errorf("failed to consume a key's colon separator: %v", err)
                         }</span>
 
                         <span class="cov8" title="1">val, re, err := rdr.readValue()
-                        if err != nil </span><span class="cov8" title="1">{
+                        if err != nil </span><span class="cov0" title="0">{
                                 rec.Fields[key] = val
-                                rs = append(rs, rec)
-                                if err == io.EOF </span><span class="cov8" title="1">{
-                                        return rs, err
-                                }</span>
-                                <span class="cov0" title="0">return rs, err</span>
+                                rc &lt;- rec
+                                </span>if err == io.EOF {
+                                        return fmt.Errorf("found an EOF while reading a value: %v", err)
+                        <span class="cov8" title="1">        }
+                                return fmt.Er</span><span class="cov8" title="1">rorf("failed to read a value: %v", err)
                         }
 
-                        // Add the key/value to the record as well.
-                        <span class="cov8" title="1">if _, ok := rec.Fields[key]; !ok </span><span class="cov8" title="1">{
-                                rec.Fields[key] = val
-                        }</span><span class="cov8" title="1"> else {
-                                rec.Fields[key] = fmt.Sprintf("%v %v", rec.Fields[key], val)
-                        }</span>
-
-                        <span class="cov8" title="1">if re </span><span class="cov8" title="1">{
-                                break</span>
+                        // Add the key/val</span><span class="cov8" title="1">ue to the record as well.
+                        if _, ok := rec.Fields[key]; !ok {
+                                r</span>ec.Fields[key] = val
+                        }<span class="cov0" title="0"> else {
+</span>                                rec.Fields[key] = fmt.Sprintf("%v %v", rec.Fields[key], val)
                         }
+
+                        <span class="cov8" title="1">if re {
+</span>                                break
+                        }</span><span class="cov8" title="1">
                 }
-                // TODO(morrowc): As with above each record created
-                // should be sent into a channel to be collected by the caller.
-                <span class="cov8" title="1">rs = append(rs, rec)</span>
+                rc</span> &lt;- rec
         }
+        re<span class="cov8" title="1">turn n</span><span class="cov8" title="1">il
 }
 </pre>
 

--- a/rpsl-parser/coverage.html
+++ b/rpsl-parser/coverage.html
@@ -54,7 +54,7 @@
 			<div id="nav">
 				<select id="files">
 
-				<option value="file0">./irr.go (90.4%)</option>
+				<option value="file0">./irr.go (90.9%)</option>
 
 				<option value="file1">./util.go (85.0%)</option>
 
@@ -454,7 +454,6 @@ func Parse(rdr *Reader, rc chan&lt;- *Record) error <span class="cov8" title="1"
                 }
                 <span class="cov8" title="1">rc &lt;- rec</span>
         }
-        <span class="cov0" title="0">return nil</span>
 }
 </pre>
 

--- a/rpsl-parser/irr.go
+++ b/rpsl-parser/irr.go
@@ -382,5 +382,4 @@ func Parse(rdr *Reader, rc chan<- *Record) error {
 		}
 		rc <- rec
 	}
-	return nil
 }

--- a/rpsl-parser/irr_test.go
+++ b/rpsl-parser/irr_test.go
@@ -735,11 +735,6 @@ func TestParse(t *testing.T) {
 		}},
 		rec:  0,
 		recs: 1,
-	}, {
-		desc:    "Fail - Illegal Keyword",
-		file:    "illegal.txt",
-		wantErr: true,
-		recs:    1,
 	}}
 
 	for _, test := range tests {
@@ -755,14 +750,8 @@ func TestParse(t *testing.T) {
 		rc := make(chan *Record, 10)
 
 		// Run the parse routine, pull the Records off the channel.
-		err = func() error {
-			err := Parse(r, rc)
-			if err != nil {
-				close(rc)
-				return err
-			}
-			return nil
-		}()
+		Parse(r, rc)
+		close(rc)
 
 		if strings.HasSuffix(fmt.Sprintf("%s", err), "EOF") {
 			err = nil

--- a/rpsl-parser/irr_test.go
+++ b/rpsl-parser/irr_test.go
@@ -17,7 +17,6 @@ package rpsl
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -759,9 +758,6 @@ func TestParse(t *testing.T) {
 		err = func() error {
 			err := Parse(r, rc)
 			if err != nil {
-				if err != io.EOF {
-					fmt.Printf("[%v]: Got error on parse: %v\n", test.desc, err)
-				}
 				close(rc)
 				return err
 			}

--- a/rpsl-parser/irr_test.go
+++ b/rpsl-parser/irr_test.go
@@ -746,10 +746,24 @@ func TestParse(t *testing.T) {
 		}
 
 		r := NewReader(fd)
-		got, err := Parse(r)
+		rc := make(chan *Record, 10)
+
+		go func() error {
+			err := Parse(r, rc)
+			if err != nil {
+				return err
+			}
+			return nil
+		}()
 		if err == io.EOF {
 			err = nil
 		}
+
+		var got []*Record
+		for i := 0; i <= test.rec; i++ {
+			got = append(got, <-rc)
+		}
+
 		switch {
 		case err != nil && !test.wantErr:
 			t.Errorf("[%v]: got error when not expecting one: %v", test.desc, err)


### PR DESCRIPTION
Move the Parse function from emitting a []Records to filling a channel with Records.

callers can now just open the channel and read as soon as records are available.
This should enable a caller to open many files at once and parse the data into Records to be consumed asynchronously.