### PR TITLE
Update irr.go, proto from github, not locally.

### DIFF
--- a/rpsl-parser/irr.go
+++ b/rpsl-parser/irr.go
@@ -24,7 +24,7 @@ import (
 	"io"
 	"strings"
 
-	rppb "./proto"
+	rppb "github.com/manrs-tools/contrib/rpsl-parser/proto"
 
 	glog "github.com/golang/glog"
 )


### PR DESCRIPTION
go would prefer we look for the proto remotely not locally.