### PR TITLE
Couple of updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,4 @@ require (
 	github.com/manrs-tools/contrib v0.0.0-20190703155503-b9ddd2b08592
 )
 
-require google.golang.org/protobuf v1.26.0 // indirect
+require google.golang.org/protobuf v1.27.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,5 +11,6 @@ github.com/manrs-tools/contrib v0.0.0-20190703155503-b9ddd2b08592/go.mod h1:TWtX
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=

--- a/rpsl-parser/util.go
+++ b/rpsl-parser/util.go
@@ -16,16 +16,6 @@
 
 package rpsl
 
-// IsLetter validates that the rune is a letter.
-func IsLetter(ch rune) bool {
-	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
-}
-
-// IsDigit validates that the rune is a number.
-func isDigit(ch rune) bool {
-	return (ch >= '0' && ch <= '9')
-}
-
 // IsWhitespace validates if the rune is a space or tab.
 func IsWhitespace(ch rune) bool {
 	return ch == ' ' || ch == '\t' || ch == '\n'

--- a/rpsl-parser/util_test.go
+++ b/rpsl-parser/util_test.go
@@ -22,52 +22,6 @@ import (
 	"testing"
 )
 
-func TestIsLetter(t *testing.T) {
-	tests := []struct {
-		desc string
-		char rune
-		want bool
-	}{{
-		desc: "Sucess letter a",
-		char: rune('a'),
-		want: true,
-	}, {
-		desc: "Fail letter 1",
-		char: rune('1'),
-		want: false,
-	}}
-
-	for _, test := range tests {
-		got := IsLetter(test.char)
-		if test.want != got {
-			t.Errorf("[%v]: failed got: %v want: %v", test.desc, got, test.want)
-		}
-	}
-}
-
-func TestIsDigit(t *testing.T) {
-	tests := []struct {
-		desc string
-		char rune
-		want bool
-	}{{
-		desc: "Sucess number 1",
-		char: rune('1'),
-		want: true,
-	}, {
-		desc: "Fail number a",
-		char: rune('a'),
-		want: false,
-	}}
-
-	for _, test := range tests {
-		got := isDigit(test.char)
-		if test.want != got {
-			t.Errorf("[%v]: failed got: %v want: %v", test.desc, got, test.want)
-		}
-	}
-}
-
 func TestIsWhitespace(t *testing.T) {
 	tests := []struct {
 		desc string

--- a/rpsl-tools/main.go
+++ b/rpsl-tools/main.go
@@ -27,7 +27,7 @@ import (
 	"os"
 	"strings"
 
-	glog "github.com/golang/glog"
+	"github.com/golang/glog"
 	rpsl "github.com/manrs-tools/contrib/rpsl-parser"
 	rppb "github.com/manrs-tools/contrib/rpsl-parser/proto"
 )


### PR DESCRIPTION
1 - no need to preface the glog import if the import name is the same
2 - unicode already has an isletter function
3 - isdigit isn't used anywhere, but unicode also has one if needed


I was debating whether to wrap the isletter function into the unicode one but I think that's messy. We already have a working function with tests

4 - finally, errors should not be capitalized or have newlines